### PR TITLE
Add cross-tab feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Oto storage uses the JavaScript Proxy API to let you interact with browser stora
 
 - **Custom Encryption Hooks**: Encrypt/decrypt stored values with your own sync crypto callbacks.
 
+- **Cross-Tab Sync API**: Subscribe to `storage` events with typed callbacks.
+
 ### 🚀 Quick Start
 
 **_1. Define your Schema_**
@@ -222,6 +224,28 @@ delete storage.count;
 
 // Clear all keys with this storage's prefix
 storage.clearAll();
+```
+
+**Cross-tab Sync**
+
+Listen for updates made in other tabs/windows for the same origin.
+
+```typescript
+const storage = oto<{ theme: "light" | "dark"; count: number }>({
+  prefix: "app-",
+});
+
+const stopAll = storage.subscribe((change) => {
+  console.log(change.key, change.oldValue, "->", change.newValue);
+});
+
+const stopTheme = storage.onChange("theme", (value) => {
+  console.log("Theme changed to:", value);
+});
+
+// Later
+stopTheme();
+stopAll();
 ```
 
 **Type Safety at Work**

--- a/docs/api/oto.md
+++ b/docs/api/oto.md
@@ -1,7 +1,9 @@
 # `oto`
 
 ```ts
-function oto<T extends object>(options?: StorageOptions): T;
+function oto<T extends object>(
+  options?: StorageOptions,
+): T & OtoMethods<T>;
 ```
 
 Creates a typed proxy over `localStorage` (default) or `sessionStorage`.
@@ -25,3 +27,17 @@ const storage = oto<AppStorage>({
 - Nested object updates are proxied.
 - Expired values are removed on access when `ttl` is enabled.
 - Encryption wrapper is used when `encryption` is configured.
+- `subscribe` and `onChange` listen for cross-tab changes via the `storage` event.
+
+## Cross-tab sync methods
+
+```ts
+interface OtoMethods<T extends object> {
+  clearAll(): void;
+  subscribe(listener: (change: OtoChangeEvent<T>) => void): () => void;
+  onChange<K extends keyof T>(
+    key: K,
+    listener: (value: T[K] | undefined, change: OtoChangeEvent<T, K>) => void,
+  ): () => void;
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oto-storage",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "A lightweight, type-safe wrapper for localStorage and sessionStorage using the Proxy API.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,26 @@ interface ReadStoredResult {
   wasEncrypted: boolean;
 }
 
+type Unsubscribe = () => void;
+
+interface OtoChangeEvent<T extends object, K extends keyof T = keyof T> {
+  key: K;
+  newValue: T[K] | undefined;
+  oldValue: T[K] | undefined;
+}
+
+interface OtoMethods<T extends object> {
+  clearAll: () => void;
+  subscribe: (listener: (change: OtoChangeEvent<T>) => void) => Unsubscribe;
+  onChange: <K extends keyof T>(
+    key: K,
+    listener: (
+      value: T[K] | undefined,
+      change: OtoChangeEvent<T, K>,
+    ) => void,
+  ) => Unsubscribe;
+}
+
 function deepMerge(target: any, source: any): any {
   if (source === null || source === undefined) return target;
   if (target === null || target === undefined) return source;
@@ -195,6 +215,17 @@ function readStoredValue(
     expired: false,
     wasEncrypted,
   };
+}
+
+function parseStorageEventValue(
+  storedValue: string | null,
+  ttl?: number,
+  encryption?: StorageEncryptionOptions,
+): any {
+  if (storedValue === null) return undefined;
+  const readResult = readStoredValue(storedValue, ttl, encryption);
+  if (readResult.expired || readResult.decryptionError) return undefined;
+  return readResult.value;
 }
 
 function getValueAtPath(
@@ -454,7 +485,9 @@ function createNestedProxy(
   });
 }
 
-export function oto<T extends object>(options: StorageOptions = {}): T {
+export function oto<T extends object>(
+  options: StorageOptions = {},
+): T & OtoMethods<T> {
   const { prefix = "", type = "local", defaults = {}, ttl, encryption } = options;
   const storage =
     typeof window !== "undefined"
@@ -474,7 +507,64 @@ export function oto<T extends object>(options: StorageOptions = {}): T {
     },
   };
 
-  return new Proxy({} as T, {
+  const anyListeners = new Set<(change: OtoChangeEvent<T>) => void>();
+  const keyListeners = new Map<keyof T, Set<(change: OtoChangeEvent<T, any>) => void>>();
+  let detachStorageListener: Unsubscribe | null = null;
+
+  const notifyListeners = (change: OtoChangeEvent<T>) => {
+    anyListeners.forEach((listener) => listener(change));
+    const listenersForKey = keyListeners.get(change.key);
+    if (!listenersForKey) return;
+    listenersForKey.forEach((listener) => listener(change));
+  };
+
+  const ensureStorageListener = () => {
+    if (
+      detachStorageListener ||
+      typeof window === "undefined" ||
+      typeof window.addEventListener !== "function"
+    ) {
+      return;
+    }
+
+    const handler = (event: StorageEvent) => {
+      if (event.storageArea !== safeStorage || !event.key) return;
+      if (!event.key.startsWith(prefix)) return;
+
+      const key = event.key.slice(prefix.length) as keyof T;
+      const newValue = parseStorageEventValue(
+        event.newValue,
+        ttl,
+        encryption,
+      ) as T[keyof T] | undefined;
+      const oldValue = parseStorageEventValue(
+        event.oldValue,
+        ttl,
+        encryption,
+      ) as T[keyof T] | undefined;
+
+      notifyListeners({
+        key,
+        newValue,
+        oldValue,
+      });
+    };
+
+    window.addEventListener("storage", handler);
+    detachStorageListener = () => {
+      if (typeof window !== "undefined") {
+        window.removeEventListener("storage", handler);
+      }
+      detachStorageListener = null;
+    };
+  };
+
+  const maybeDetachStorageListener = () => {
+    if (anyListeners.size > 0 || keyListeners.size > 0) return;
+    detachStorageListener?.();
+  };
+
+  return new Proxy({} as T & OtoMethods<T>, {
     get(_target, prop: string) {
       if (prop === "clearAll") {
         return () => {
@@ -486,6 +576,44 @@ export function oto<T extends object>(options: StorageOptions = {}): T {
           keys.forEach((key) => {
             if (key.startsWith(prefix)) safeStorage.removeItem(key);
           });
+        };
+      }
+      if (prop === "subscribe") {
+        return (listener: (change: OtoChangeEvent<T>) => void): Unsubscribe => {
+          anyListeners.add(listener);
+          ensureStorageListener();
+          return () => {
+            anyListeners.delete(listener);
+            maybeDetachStorageListener();
+          };
+        };
+      }
+      if (prop === "onChange") {
+        return <K extends keyof T>(
+          key: K,
+          listener: (
+            value: T[K] | undefined,
+            change: OtoChangeEvent<T, K>,
+          ) => void,
+        ): Unsubscribe => {
+          const wrappedListener = (change: OtoChangeEvent<T, K>) => {
+            listener(change.newValue, change);
+          };
+          const listenersForKey = keyListeners.get(key) || new Set();
+          listenersForKey.add(wrappedListener as (change: OtoChangeEvent<T, any>) => void);
+          keyListeners.set(key, listenersForKey);
+          ensureStorageListener();
+          return () => {
+            const currentListeners = keyListeners.get(key);
+            if (!currentListeners) return;
+            currentListeners.delete(
+              wrappedListener as (change: OtoChangeEvent<T, any>) => void,
+            );
+            if (currentListeners.size === 0) {
+              keyListeners.delete(key);
+            }
+            maybeDetachStorageListener();
+          };
         };
       }
       const fullKey = `${prefix}${prop}`;
@@ -570,4 +698,4 @@ export function oto<T extends object>(options: StorageOptions = {}): T {
 }
 
 export const version = "0.4.3";
-export type { StorageOptions, StorageEncryptionOptions };
+export type { OtoChangeEvent, OtoMethods, StorageOptions, StorageEncryptionOptions };

--- a/src/index.ts
+++ b/src/index.ts
@@ -697,5 +697,5 @@ export function oto<T extends object>(
   });
 }
 
-export const version = "0.4.3";
+export const version = "0.4.4";
 export type { OtoChangeEvent, OtoMethods, StorageOptions, StorageEncryptionOptions };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-Tab Sync API: subscribe() to listen for any storage key changes, onChange() for specific keys, and clearAll() to clear storage. Both subscribe/onChange return cleanup functions.

* **Documentation**
  * API docs updated with Cross-Tab Sync section and usage examples.

* **Tests**
  * Added tests validating cross-tab storage event delivery and unsubscribe behavior.

* **Chores**
  * Package version bumped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->